### PR TITLE
Add support for restarting connection by wrapping PDO into a new object

### DIFF
--- a/src/SimpleDatabase.php
+++ b/src/SimpleDatabase.php
@@ -13,11 +13,11 @@ use Psr\Log\LoggerInterface;
 class SimpleDatabase
 {
     /**
-     * @var PDO
+     * @var SimpleDatabasePdo
      */
     private $pdo;
     /**
-     * @var PDO
+     * @var SimpleDatabasePdo
      */
     private $readOnlyPdo;
     /**
@@ -30,10 +30,10 @@ class SimpleDatabase
     private $queryLogger;
 
     /**
-     * @param PDO $pdo
+     * @param SimpleDatabasePdo $pdo
      * @param LoggerInterface $logger
      * @param bool $logQueries
-     * @param PDO|null $readOnlyPDO
+     * @param SimpleDatabasePdo|null $readOnlyPDO
      *  If this parameter is passed, then read/write separation will be enabled. $pdo parameter will be the one
      *  responsible for write operations, and $readOnlyPDO will be connection responsible for reading data.
      */
@@ -560,5 +560,13 @@ class SimpleDatabase
     public function isReadWriteSeparationEnabled()
     {
         return $this->readOnlyPdo !== null;
+    }
+
+    /**
+     * @return bool
+     */
+    public function resetConnection(): bool
+    {
+        return true;
     }
 }

--- a/src/SimpleDatabase.php
+++ b/src/SimpleDatabase.php
@@ -244,7 +244,7 @@ class SimpleDatabase
 
         return $result;
     }
-    
+
     /**
      * @return bool
      */
@@ -567,6 +567,23 @@ class SimpleDatabase
      */
     public function resetConnection(): bool
     {
-        return true;
+        if ($this->pdo instanceof SimpleDatabasePdo) {
+            $this->pdo = new PDO(
+                $this->pdo->getDsn(),
+                $this->pdo->getUsername(),
+                $this->pdo->getPassword(),
+                $this->pdo->getOptions()
+            );
+            if ($this->readOnlyPdo instanceof SimpleDatabasePdo) {
+                $this->readOnlyPdo = new PDO(
+                    $this->readOnlyPdo->getDsn(),
+                    $this->readOnlyPdo->getUsername(),
+                    $this->readOnlyPdo->getPassword(),
+                    $this->readOnlyPdo->getOptions()
+                );
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/src/SimpleDatabasePdo.php
+++ b/src/SimpleDatabasePdo.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace Assertis\SimpleDatabase;
+
+use PDO;
+
+/**
+ * @author Łukasz Nowak.
+ */
+class SimpleDatabasePdo extends PDO
+{
+    /**
+     * @var string
+     */
+    private $dsn;
+    /**
+     * @var string
+     */
+    private $username;
+    /**
+     * @var string
+     */
+    private $password;
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(
+        string $dsn,
+        string $username,
+        string $password,
+        array $options
+    ) {
+        $this->dsn = $dsn;
+        $this->username = $username;
+        $this->password = $password;
+        $this->options = $options;
+        parent::__construct($this->dsn, $this->username, $this->password, $this->options);
+    }
+
+    /**
+     * @return string
+     */
+    public function getDsn(): string
+    {
+        return $this->dsn;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}


### PR DESCRIPTION
I need it in ride-service because with new data there before moving _tmp tables to the appropiate tables PDO connection says 
`<WARNING> User Notice: Connection closed prematurely ` or sometimes `PDOStatement::execute(): Error reading result set's header`

All because connection is stored too long. That's why we don`t update sardines properly and _tmp tables still exist in database and are not removed properly. 